### PR TITLE
fix(deps): add missing autoprefixer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react-dom": "^18",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.3"
   }


### PR DESCRIPTION
Adds `autoprefixer` to `devDependencies`. This is a required peer dependency for Tailwind CSS and was causing the application to fail at build time with a 'Cannot find module' error.