### PR TITLE
fix(import): add missing CardFooter import

### DIFF
--- a/src/app/main-dashboard/page.tsx
+++ b/src/app/main-dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/Card";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { Activity, ArrowUpRight, Search, Map, Edit } from 'lucide-react'; // Assuming I can't install, I'll mock these or use emojis.


### PR DESCRIPTION
Adds `CardFooter` to the import statement in `src/app/main-dashboard/page.tsx`. This was causing a runtime error as the component was being used but not imported.