### PR TITLE
fix: Resolve Vite migration issues and finalize setup

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Link from 'next/link';
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/utils';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   href?: string;
@@ -7,7 +8,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'default' | 'sm' | 'lg' | 'icon';
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
   ({ href, variant = 'primary', size = 'default', className, children, ...props }, ref) => {
 
     const baseClasses = "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none";
@@ -27,15 +28,21 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       icon: "h-10 w-10",
     };
 
-    const finalClassName = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className || ''}`;
+    const finalClassName = cn(baseClasses, variantClasses[variant], sizeClasses[size], className);
 
-    const buttonContent = (
-      <button className={finalClassName} ref={ref} {...props}>
+    if (href) {
+      return (
+        <Link to={href} className={finalClassName} ref={ref as React.ForwardedRef<HTMLAnchorElement>} {...props}>
+          {children}
+        </Link>
+      );
+    }
+
+    return (
+      <button className={finalClassName} ref={ref as React.ForwardedRef<HTMLButtonElement>} {...props}>
         {children}
       </button>
     );
-
-    return href ? <Link href={href}>{buttonContent}</Link> : buttonContent;
   }
 );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,24 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+    "noEmit": true,
+    "jsx": "react-jsx",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This commit fixes critical issues that arose after the initial migration to Vite. The application is now fully configured to run in a Vite environment, free of legacy Next.js dependencies.

Key fixes:
- **Button Component**: The `Button` component was still importing and using `next/link`, which caused the Vite development server to fail. This has been corrected to use the `Link` component from `react-router-dom`, resolving the startup error.
- **TSConfig**: The `tsconfig.json` file contained several Next.js-specific configurations (such as plugins and include paths). It has been updated with a standard configuration suitable for a Vite + React + TypeScript project.
- **Next.js Remnants**: A thorough search was conducted to ensure no other Next.js-specific code or configurations remained.