### PR TITLE
fix: Remove duplicate React import in main.tsx

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './styles/globals.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/globals.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);


### PR DESCRIPTION
This commit resolves a startup error caused by a duplicated `import React` statement in the main application entry point (`src/main.tsx`). This error was introduced during a previous refactoring.

The file has been cleaned up to ensure each module is imported only once.