### PR TITLE
feat: Implement 'Post a Job' page with a functional form

### DIFF
--- a/src/pages/WorkCreatePage.tsx
+++ b/src/pages/WorkCreatePage.tsx
@@ -1,17 +1,102 @@
 import React from 'react';
 import MobileLayout from '@/components/layout/MobileLayout';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
 
-const PlaceholderContent = ({ title }: { title: string }) => (
-    <div className="p-8 text-center">
-        <h2 className="text-2xl font-bold">{title}</h2>
-        <p className="text-gray-500 mt-2">This page is under construction.</p>
-    </div>
+const Label = ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" {...props}>
+    {children}
+  </label>
 );
 
 const WorkCreatePage: React.FC = () => {
+  const [formData, setFormData] = React.useState({
+    title: '',
+    description: '',
+    location: '',
+    rate: '',
+    unit: 'hour',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log("Form Submitted:", formData);
+    // Here you would typically send the data to a server
+    alert(`Job "${formData.title}" posted successfully! (Check console for data)`);
+  };
+
   return (
     <MobileLayout headerText="Post a Job">
-      <PlaceholderContent title="Create a New Job" />
+      <div className="p-4">
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div>
+            <Label htmlFor="title">Job Title</Label>
+            <Input
+              id="title"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              placeholder="e.g., Vineyard Pruning"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="description">Job Description</Label>
+            <Textarea
+              id="description"
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              placeholder="Describe the work, requirements, etc."
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="location">Location</Label>
+            <Input
+              id="location"
+              name="location"
+              value={formData.location}
+              onChange={handleChange}
+              placeholder="e.g., Barossa Valley, SA"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="rate">Pay Rate</Label>
+              <Input
+                id="rate"
+                name="rate"
+                type="number"
+                value={formData.rate}
+                onChange={handleChange}
+                placeholder="e.g., 28"
+              />
+            </div>
+            <div>
+              <Label htmlFor="unit">Per</Label>
+              <Input
+                id="unit"
+                name="unit"
+                value={formData.unit}
+                onChange={handleChange}
+                placeholder="Hour / Day"
+              />
+            </div>
+          </div>
+
+          <div>
+            <Button type="submit" className="w-full">Post Job Listing</Button>
+          </div>
+        </form>
+      </div>
     </MobileLayout>
   );
 };


### PR DESCRIPTION
This commit replaces the placeholder 'Post a Job' page with a fully functional form, enabling users to create new job listings.

The new page (`src/pages/WorkCreatePage.tsx`) includes:
- A clean, well-structured form for entering job details such as title, description, location, and pay rate.
- State management for all form fields using the `useState` hook, with all inputs implemented as controlled components.
- An `onSubmit` handler that processes the form data. Currently, it logs the data to the console and shows an alert to simulate a successful submission.
- The form is built using the existing reusable UI components (`Input`, `Textarea`, `Button`) for a consistent design.