### PR TITLE
fix(WorkCreatePage): Correct import statement for Input component

### DIFF
--- a/src/pages/WorkCreatePage.tsx
+++ b/src/pages/WorkCreatePage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MobileLayout from '@/components/layout/MobileLayout';
 import Button from '@/components/ui/Button';
-import Input from '@/components/ui/Input';
+import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 
 const Label = ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (


### PR DESCRIPTION
This commit fixes a JavaScript module error on the 'Post a Job' page (`WorkCreatePage.tsx`). The page was attempting to import the `Input` component using a default import, but the component is exported using a named export.

The import statement has been changed from `import Input from ...` to `import { Input } from ...` to resolve the `Uncaught SyntaxError`.