### PR TITLE
fix(layout): Ensure bottom navigation is always fixed to bottom

### DIFF
--- a/src/components/layout/MobileLayout.tsx
+++ b/src/components/layout/MobileLayout.tsx
@@ -16,9 +16,9 @@ const MobileLayout = ({ children, headerText }: { children: React.ReactNode, hea
 
   return (
     <iPhoneFrame>
-      <div className="relative flex flex-col h-full bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+      <div className="flex flex-col h-full bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
         {/* App Header */}
-        <header className="flex items-center justify-between flex-shrink-0 px-4 h-14 border-b border-gray-200 dark:border-gray-700">
+        <header className="flex-shrink-0 flex items-center justify-between px-4 h-14 border-b border-gray-200 dark:border-gray-700">
           <h1 className="text-xl font-bold">{headerText}</h1>
           <button className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700">
             <Bell size={22} />
@@ -26,12 +26,12 @@ const MobileLayout = ({ children, headerText }: { children: React.ReactNode, hea
         </header>
 
         {/* Scrollable Content Area */}
-        <main className="flex-1 overflow-y-auto pb-16">
+        <main className="flex-1 overflow-y-auto">
           {children}
         </main>
 
         {/* Bottom Navigation */}
-        <nav className="absolute bottom-0 left-0 right-0 flex justify-around h-16 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
+        <nav className="flex-shrink-0 flex justify-around h-16 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
           {navItems.map((item) => {
             const isActive = location.pathname === item.href || (item.href === '/main-dashboard' && location.pathname === '/');
             return (


### PR DESCRIPTION
This commit refactors the `MobileLayout` component to use a more robust, pure flexbox-based layout. This resolves an issue where the bottom navigation bar was not reliably fixed to the bottom of the screen on all pages.

The previous implementation, which mixed flexbox with absolute positioning, has been replaced. The new layout consists of a vertical flex container where the main content area grows to fill all available space, pushing the navigation bar to the bottom. This is a standard and more reliable method for achieving a "sticky footer" or "sticky tab bar" effect.